### PR TITLE
pin swift-collections to 1.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftwasm/JavaScriptKit", .upToNextMinor(from: "0.50.0")),
         .package(url: "https://github.com/elementary-swift/elementary", from: "0.7.0"),
-        .package(url: "https://github.com/apple/swift-collections", from: "1.4.0", traits: ["UnstableContainersPreview"]),
+        .package(url: "https://github.com/apple/swift-collections", .upToNextMinor(from: "1.4.0"), traits: ["UnstableContainersPreview"]),
         .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"604.0.0"),
     ],
     targets: [


### PR DESCRIPTION
swift-collections 1.5 introduces a linker error in embedded (along with a few deprecations), this is a temporary patch to avoid the error by pinning the version to 1.4.